### PR TITLE
Add ability to send to topic threads and fix error if no players are connected

### DIFF
--- a/config.php.sample
+++ b/config.php.sample
@@ -4,6 +4,7 @@ $config = [
   "server_url" => "localhost", // URL of your Minecraft server. Leave localhost in here if it's running on the same server as this script
   "server_port" => "25565", // Minecraft server port (not the rcon or query port!), default is 25565
   "chat_id" => "", // Starts with a dash
+  "reply_to_message_id" => "", // message_id of created topic thread if you want to send to a topic
   "lang" => "en", // The language your bot should speak – German (de), Russian (ru), Polish (pl) and of course English (en) are supported
 ];
 ?>

--- a/index.php
+++ b/index.php
@@ -41,6 +41,7 @@ function get_live_playerlist()
   try {
     $Query->Connect($config["server_url"], $config["server_port"]);
     $playerlist = $Query->GetPlayers();
+    $playerlist = !is_array($playerlist) ? [] : $playerlist;
     sort($playerlist);
 
     return $playerlist;

--- a/index.php
+++ b/index.php
@@ -110,6 +110,11 @@ function post_message_to_chat($message)
 
   $telegram = new Telegram($config["bot_token"]);
   $content = ["chat_id" => $config["chat_id"], "text" => $message];
+
+  if (isset($config["reply_to_message_id"]) && $config["reply_to_message_id"] != "") {
+    $content["reply_to_message_id"] = $config["reply_to_message_id"];
+  }
+  
   $result = $telegram->sendMessage($content);
 
   if ($result["error_code"] >= 400) 


### PR DESCRIPTION
An error occurred when no player is online anymore, because in this case `$playerlist` is a boolean and an error occurred due to `sort()`.

I also added `reply_to_message_id ` to let the bot send in topic threads, which require you  to reply to the message saying `"Topic" was created`.